### PR TITLE
Implement LUsb0_ControlTransfer for libusb0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.vs/
+*.user
+*.filters
+bin/
+Debug/
+Backup/

--- a/libusbK/includes/libusbk.h
+++ b/libusbK/includes/libusbk.h
@@ -4030,9 +4030,10 @@ extern "C" {
 	*
 	* \attention
 	* This function should not be used for operations supported by the library.\n e.g.
-	* \ref UsbK_SetConfiguration, \ref UsbK_SetAltInterface, etc..
+	* \ref LUsb0_SetConfiguration, \ref UsbK_SetAltInterface, etc..
 	*
 	*/
+
 	KUSB_EXP BOOL KUSB_API LUsb0_ControlTransfer(
 		_in KUSB_HANDLE InterfaceHandle,
 		_in WINUSB_SETUP_PACKET SetupPacket,
@@ -4040,6 +4041,30 @@ extern "C" {
 		_in UINT BufferLength,
 		_outopt PUINT LengthTransferred,
 		_inopt LPOVERLAPPED Overlapped);
+	//! Sets the device configuration number.
+		/*!
+		*
+		* \param[in] InterfaceHandle
+		* An initialized usb handle, see \ref UsbK_Init.
+		*
+		* \param[in] ConfigurationNumber
+		* The configuration number to activate.
+		*
+		* \returns On success, TRUE. Otherwise FALSE. Use \c GetLastError() to get extended error information.
+		*
+		* \ref LUsb0_SetConfiguration is only supported with libusb0.sys. If the driver in not libusb0.sys, this
+		* function performs the following emulation actions:
+		* - If the requested configuration number is the current configuration number, returns TRUE.
+		* - If the requested configuration number is one other than the current configuration number, returns FALSE
+		*   and set last error to \c ERROR_NO_MORE_ITEMS.
+		*
+		* This function will fail if there are pending I/O operations or there are other libusbK interface handles
+		* referencing the device. \sa UsbK_Free
+		*
+		*/
+	KUSB_EXP BOOL KUSB_API LUsb0_SetConfiguration(
+		_in KUSB_HANDLE InterfaceHandle,
+		_in UCHAR ConfigurationNumber);
 #endif
 
 #ifdef __cplusplus

--- a/libusbK/includes/libusbk.h
+++ b/libusbK/includes/libusbk.h
@@ -3991,6 +3991,55 @@ extern "C" {
 
 	/*! @} */
 
+//! Transmits control data over a default control endpoint.
+	/*!
+	*
+	* \param[in] InterfaceHandle
+	* A valid libusbK interface handle returned by:
+	* - \ref UsbK_Init
+	* - \ref UsbK_Initialize
+	* - \ref UsbK_GetAssociatedInterface
+	* - \ref UsbK_Clone
+	*
+	* \param[in] SetupPacket
+	*  The 8-byte setup packet of type WINUSB_SETUP_PACKET.
+	*
+	* \param[in,out] Buffer
+	* A caller-allocated buffer that contains the data to transfer.
+	*
+	* \param[in] BufferLength
+	* The number of bytes to transfer, not including the setup packet. This number must be less than or equal to
+	* the size, in bytes, of Buffer.
+	*
+	* \param[out] LengthTransferred
+	* A pointer to a UINT variable that receives the actual number of transferred bytes. If the application
+	* does not expect any data to be transferred during the data phase (BufferLength is zero), LengthTransferred
+	* can be NULL.
+	*
+	* \param[in] Overlapped
+	* An optional pointer to an OVERLAPPED structure, which is used for asynchronous operations. If this
+	* parameter is specified, \ref UsbK_ControlTransfer immediately returns, and the event is signaled when the
+	* operation is complete. If Overlapped is not supplied, the \ref UsbK_ControlTransfer function transfers
+	* data synchronously.
+	*
+	* \returns On success, TRUE. Otherwise FALSE. Use \c GetLastError() to get extended error information. If an
+	* \c Overlapped member is supplied and the operation succeeds this function returns FALSE and sets last
+	* error to ERROR_IO_PENDING.
+	*
+	* A \ref UsbK_ControlTransfer is never cached. These requests always go directly to the usb device.
+	*
+	* \attention
+	* This function should not be used for operations supported by the library.\n e.g.
+	* \ref UsbK_SetConfiguration, \ref UsbK_SetAltInterface, etc..
+	*
+	*/
+	KUSB_EXP BOOL KUSB_API LUsb0_ControlTransfer(
+		_in KUSB_HANDLE InterfaceHandle,
+		_in WINUSB_SETUP_PACKET SetupPacket,
+		_refopt PUCHAR Buffer,
+		_in UINT BufferLength,
+		_outopt PUINT LengthTransferred,
+		_inopt LPOVERLAPPED Overlapped);
 #endif
 
 #ifdef __cplusplus

--- a/libusbK/src/lusbk_bknd_libusb0.c
+++ b/libusbK/src/lusbk_bknd_libusb0.c
@@ -59,7 +59,11 @@ KUSB_EXP BOOL KUSB_API LUsb0_ControlTransfer(
 
 	if (ret >= 0)
 	{
-		*LengthTransferred = ret;
+		if (LengthTransferred != NULL)
+		{
+			*LengthTransferred = ret;
+		}
+
 		success = TRUE;
 	}
 	else

--- a/libusbK/src/lusbk_bknd_libusb0.c
+++ b/libusbK/src/lusbk_bknd_libusb0.c
@@ -21,3 +21,232 @@ binary distributions.
 #include "lusbk_stack_collection.h"
 
 
+/*
+ * Standard requests
+ */
+
+#define USB_TYPE_STANDARD		(0x00 << 5)
+#define USB_TYPE_CLASS			(0x01 << 5)
+#define USB_TYPE_VENDOR			(0x02 << 5)
+
+/*
+ * Various libusb API related stuff
+ */
+
+#define USB_ENDPOINT_IN			0x80
+#define USB_ENDPOINT_OUT		0x00
+
+KUSB_EXP BOOL KUSB_API LUsb0_ControlTransfer(
+	_in KUSB_HANDLE InterfaceHandle,
+	_in WINUSB_SETUP_PACKET SetupPacket,
+	_refopt PUCHAR Buffer,
+	_in UINT BufferLength,
+	_outopt PUINT LengthTransferred,
+	_inopt LPOVERLAPPED Overlapped)
+{
+	BOOL success;
+	int ret;
+	PKUSB_HANDLE_INTERNAL handle;
+
+	Pub_To_Priv_UsbK(InterfaceHandle, handle, return FALSE);
+	ErrorSetAction(!PoolHandle_Inc_UsbK(handle), ERROR_RESOURCE_NOT_AVAILABLE, return FALSE, "->PoolHandle_Inc_UsbK");
+
+	ret = usb_control_msg(Dev_Handle(), SetupPacket.RequestType, SetupPacket.Request, SetupPacket.Value, SetupPacket.Index, Buffer, BufferLength, /* timeout */ 1000);
+
+	if (ret >= 0)
+	{
+		LengthTransferred = ret;
+		success = TRUE;
+	}
+	else
+	{
+		success = FALSE;
+	}
+
+	PoolHandle_Dec_UsbK(handle);
+
+	return success;
+}
+
+// See libusb-win32 windows.c:671-815
+int usb_control_msg(HANDLE *dev, int requesttype, int request,
+	int value, int index, char *bytes, int size, int timeout)
+{
+	int read = 0;
+	libusb_request req;
+	void *out = &req;
+	int out_size = sizeof(libusb_request);
+	void *in = bytes;
+	int in_size = size;
+	int code;
+
+	if (!dev)
+	{
+		USBERR("device not open\n");
+		return -EINVAL;
+	}
+
+	req.timeout = timeout;
+
+	/* windows doesn't support generic control messages, so it needs to be */
+	/* split up */
+	switch (requesttype & (0x03 << 5))
+	{
+	case USB_TYPE_STANDARD:
+		switch (request)
+		{
+		case USB_REQUEST_GET_STATUS:
+			req.status.recipient = requesttype & 0x1F;
+			req.status.index = index;
+			code = LIBUSB_IOCTL_GET_STATUS;
+			break;
+
+		case USB_REQUEST_CLEAR_FEATURE:
+			req.feature.recipient = requesttype & 0x1F;
+			req.feature.feature = value;
+			req.feature.index = index;
+			code = LIBUSB_IOCTL_CLEAR_FEATURE;
+			break;
+
+		case USB_REQUEST_SET_FEATURE:
+			req.feature.recipient = requesttype & 0x1F;
+			req.feature.feature = value;
+			req.feature.index = index;
+			code = LIBUSB_IOCTL_SET_FEATURE;
+			break;
+
+		case USB_REQUEST_GET_DESCRIPTOR:
+			req.descriptor.recipient = requesttype & 0x1F;
+			req.descriptor.type = (value >> 8) & 0xFF;
+			req.descriptor.index = value & 0xFF;
+			req.descriptor.language_id = index;
+			code = LIBUSB_IOCTL_GET_DESCRIPTOR;
+			break;
+
+		case USB_REQUEST_SET_DESCRIPTOR:
+			req.descriptor.recipient = requesttype & 0x1F;
+			req.descriptor.type = (value >> 8) & 0xFF;
+			req.descriptor.index = value & 0xFF;
+			req.descriptor.language_id = index;
+			code = LIBUSB_IOCTL_SET_DESCRIPTOR;
+			break;
+
+		case USB_REQUEST_GET_CONFIGURATION:
+			code = LIBUSB_IOCTL_GET_CONFIGURATION;
+			break;
+
+		case USB_REQUEST_SET_CONFIGURATION:
+			req.configuration.configuration = value;
+			code = LIBUSB_IOCTL_SET_CONFIGURATION;
+			break;
+
+		case USB_REQUEST_GET_INTERFACE:
+			req.intf.interface_number = index;
+			code = LIBUSB_IOCTL_GET_INTERFACE;
+			break;
+
+		case USB_REQUEST_SET_INTERFACE:
+			req.intf.interface_number = index;
+			req.intf.altsetting_number = value;
+			code = LIBUSB_IOCTL_SET_INTERFACE;
+			break;
+
+		default:
+			USBERR("invalid request 0x%x", request);
+			return -EINVAL;
+		}
+		break;
+
+	case USB_TYPE_VENDOR:
+	case USB_TYPE_CLASS:
+
+		req.vendor.type = (requesttype >> 5) & 0x03;
+		req.vendor.recipient = requesttype & 0x1F;
+		req.vendor.request = request;
+		req.vendor.value = value;
+		req.vendor.index = index;
+
+		if (requesttype & 0x80)
+			code = LIBUSB_IOCTL_VENDOR_READ;
+		else
+			code = LIBUSB_IOCTL_VENDOR_WRITE;
+		break;
+
+	default:
+		USBERR("invalid or unsupported request type: %x",
+			requesttype);
+		return -EINVAL;
+	}
+
+	/* out request? */
+	if (!(requesttype & USB_ENDPOINT_IN))
+	{
+		if (!(out = malloc(sizeof(libusb_request) + size)))
+		{
+			USBERR("memory allocation failed\n");
+			return -ENOMEM;
+		}
+
+		memcpy(out, &req, sizeof(libusb_request));
+		memcpy((char *)out + sizeof(libusb_request), bytes, size);
+		out_size = sizeof(libusb_request) + size;
+		in = NULL;
+		in_size = 0;
+	}
+
+	if (!_usb_io_sync(dev, code, out, out_size, in, in_size, &read))
+	{
+		USBERR("sending control message failed");
+		if (!(requesttype & USB_ENDPOINT_IN))
+		{
+			free(out);
+		}
+		return -1;
+	}
+
+	/* out request? */
+	if (!(requesttype & USB_ENDPOINT_IN))
+	{
+		free(out);
+		return size;
+	}
+	else
+		return read;
+}
+
+static int _usb_io_sync(HANDLE dev, unsigned int code, void *out, int out_size,
+	void *in, int in_size, int *ret)
+{
+	OVERLAPPED ol;
+	DWORD _ret;
+
+	memset(&ol, 0, sizeof(ol));
+
+	if (ret)
+		*ret = 0;
+
+	ol.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+
+	if (!ol.hEvent)
+		return FALSE;
+
+	if (!DeviceIoControl(dev, code, out, out_size, in, in_size, NULL, &ol))
+	{
+		if (GetLastError() != ERROR_IO_PENDING)
+		{
+			CloseHandle(ol.hEvent);
+			return FALSE;
+		}
+	}
+
+	if (GetOverlappedResult(dev, &ol, &_ret, TRUE))
+	{
+		if (ret)
+			*ret = (int)_ret;
+		CloseHandle(ol.hEvent);
+		return TRUE;
+	}
+
+	CloseHandle(ol.hEvent);
+	return FALSE;
+}

--- a/libusbK/src/lusbk_bknd_libusb0.h
+++ b/libusbK/src/lusbk_bknd_libusb0.h
@@ -1,0 +1,35 @@
+/*!********************************************************************
+libusbK - Multi-driver USB library.
+Copyright (C) 2012 Travis Lee Robinson. All Rights Reserved.
+libusb-win32.sourceforge.net
+
+Development : Travis Lee Robinson  (libusbdotnet@gmail.com)
+Testing     : Xiaofan Chen         (xiaofanc@gmail.com)
+
+At the discretion of the user of this library, this software may be
+licensed under the terms of the GNU Public License v3 or a BSD-Style
+license as outlined in the following files:
+* LICENSE-gpl3.txt
+* LICENSE-bsd.txt
+
+License files are located in a license folder at the root of source and
+binary distributions.
+********************************************************************!*/
+
+#define UNUSED(x) (void)(x)
+
+#ifndef ENOMEM
+#define ENOMEM          12
+#endif
+
+#ifndef EINVAL
+#define EINVAL          22
+#endif
+
+int _usb_io_sync(HANDLE dev, unsigned int code, void *out, int out_size,
+	void *in, int in_size, int *ret);
+
+int usb_control_msg(HANDLE *dev, int requesttype, int request,
+	int value, int index, PUCHAR bytes, int size, int timeout);
+
+int usb_set_configuration(HANDLE *dev, int configuration);

--- a/libusbK/src/lusbk_bknd_libusbk.c
+++ b/libusbK/src/lusbk_bknd_libusbk.c
@@ -111,7 +111,7 @@ static BOOL k_Init_Backend(PKUSB_HANDLE_INTERNAL handle)
 	return IsHandleValid(handle->Device->Backend.CtxK);
 }
 
-static BOOL k_Init_Config(PKUSB_HANDLE_INTERNAL handle)
+BOOL k_Init_Config(PKUSB_HANDLE_INTERNAL handle)
 {
 	libusb_request request;
 	UINT transferred = 0;

--- a/libusbK/src/lusbk_handles.h
+++ b/libusbK/src/lusbk_handles.h
@@ -882,3 +882,5 @@ FORCEINLINE BOOL Guid_To_String(__in GUID* Guid, __inout LPSTR GuidString)
 	return (guidLen == GUID_STRING_LENGTH);
 }
 #endif
+
+BOOL k_Init_Config(PKUSB_HANDLE_INTERNAL handle);

--- a/libusbK/src/lusbk_usb.c
+++ b/libusbK/src/lusbk_usb.c
@@ -189,6 +189,7 @@ BOOL GetProcAddress_LUsb0(__out KPROC* ProcAddress, __in LONG FunctionID)
 	default:
 		return GetProcAddress_UsbK(ProcAddress, FunctionID);
 	}
+	return TRUE;
 }
 
 KUSB_EXP BOOL KUSB_API LibK_GetProcAddress(

--- a/libusbK/src/lusbk_usb.c
+++ b/libusbK/src/lusbk_usb.c
@@ -180,6 +180,9 @@ BOOL GetProcAddress_LUsb0(__out KPROC* ProcAddress, __in LONG FunctionID)
 	case KUSB_FNID_IsoWritePipe:
 		GetProcAddress_Unsupported(ProcAddress, FunctionID);
 		return LusbwError(ERROR_NOT_SUPPORTED);
+	case KUSB_FNID_ControlTransfer:
+		*ProcAddress = (KPROC)LUsb0_ControlTransfer;
+		break;
 	default:
 		return GetProcAddress_UsbK(ProcAddress, FunctionID);
 	}

--- a/libusbK/src/lusbk_usb.c
+++ b/libusbK/src/lusbk_usb.c
@@ -180,6 +180,9 @@ BOOL GetProcAddress_LUsb0(__out KPROC* ProcAddress, __in LONG FunctionID)
 	case KUSB_FNID_IsoWritePipe:
 		GetProcAddress_Unsupported(ProcAddress, FunctionID);
 		return LusbwError(ERROR_NOT_SUPPORTED);
+	case KUSB_FNID_SetConfiguration:
+		*ProcAddress = (KPROC)LUsb0_SetConfiguration;
+		break;
 	case KUSB_FNID_ControlTransfer:
 		*ProcAddress = (KPROC)LUsb0_ControlTransfer;
 		break;


### PR DESCRIPTION
It appears the message format which `libusb0.sys` expects for control messages is different from what is currently implemented.

This PR ports part of `libusb0.dll`'s native `usb_control_msg` and integrates it in libusbK as `LUsb0_ControlTransfer`.

I've tested this locally and it appears to work, although feedback is welcome.