### PR TITLE
fix _tWinMain return

### DIFF
--- a/libusbK/src/dpscat/dpscat.c
+++ b/libusbK/src/dpscat/dpscat.c
@@ -88,8 +88,20 @@ VOID WriteInfStatus(CONST WCHAR* fmt, ...)
 		if (WriteConW(buf, len, (LPDWORD)&len))
 			return;
 
+	} 
+	else 
+	{
+		HANDLE hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
+		if (hStdOut != INVALID_HANDLE_VALUE) {
+			DWORD transferred = 0;
+			if (WriteFile(hStdOut, buf, len, &transferred, NULL)) {
+				return;
+			}
+		}
 	}
+#ifdef _DEBUG
 	OutputDebugStringW(buf);
+#endif
 }
 
 int APIENTRY _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, int nCmdShow)
@@ -165,6 +177,7 @@ int APIENTRY _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCm
 
 		FreeConsole();
 	}
+	return ret;
 }
 
 int RunProgram(int argc, LPWSTR* argv)

--- a/libusbK/src/dpscat/dpscat.vcxproj
+++ b/libusbK/src/dpscat/dpscat.vcxproj
@@ -22,6 +22,7 @@
     <ProjectGuid>{7698DE33-8D9A-455F-96B5-FD6B29009039}</ProjectGuid>
     <RootNamespace>dpscat</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/libusbK/src/dpscat/inf_parser.c
+++ b/libusbK/src/dpscat/inf_parser.c
@@ -2,8 +2,9 @@
 #include "inf_parser.h"
 #include <Shlwapi.h>
 
-// warning C4127: conditional expression is constant
-#pragma warning(disable: 4127)
+
+#pragma warning(disable: 4127) // warning C4127: conditional expression is constant
+#pragma warning(disable: 4996) // warning C4996: 'GetVersionExW': was declared deprecated
 
 BOOL KINF_API InfK_Init(PKINF_LIST* List)
 {


### PR DESCRIPTION
fix _tWinMain return
also fixed output to console and StdOut
and suppressed warning

_tWinMain was missing return statement and executable returned random error code (713 happened to be in EAX)
Also it was also writing output to console only. Added writing to StdOut if it is open (good for pipe-ing)
Also OutputDebugStringW was polluting now only in _DEBUG
And suppressed warning for deprecated Win32 API (irrelevant) 