### PR TITLE
(untested) Signal overlapped from caller in LUsb0_ControlTransfer

### DIFF
--- a/libusbK/src/lusbk_bknd_libusb0.c
+++ b/libusbK/src/lusbk_bknd_libusb0.c
@@ -50,8 +50,6 @@ KUSB_EXP BOOL KUSB_API LUsb0_ControlTransfer(
 	int ret;
 	PKUSB_HANDLE_INTERNAL handle;
 
-	UNUSED(Overlapped);
-
 	Pub_To_Priv_UsbK(InterfaceHandle, handle, return FALSE);
 	ErrorSetAction(!PoolHandle_Inc_UsbK(handle), ERROR_RESOURCE_NOT_AVAILABLE, return FALSE, "->PoolHandle_Inc_UsbK");
 
@@ -72,6 +70,9 @@ KUSB_EXP BOOL KUSB_API LUsb0_ControlTransfer(
 	}
 
 	PoolHandle_Dec_UsbK(handle);
+
+	if (Overlapped && Overlapped.hEvent)
+		return SetEvent(Overlapped.hEvent);
 
 	return success;
 }


### PR DESCRIPTION
This is an attempt to deal with libusb 1.0.24 or later which always uses
asynchronous control transfers. libusb will pass an OVERLAPPED structure and
use this afterwards to check that the transfer has finished.

The transfer will still be forced synchronous here, but by
signalling the finished transfer the caller will not be reporting
timeouts for actual finished transfers.

---

Additional merge request comments:
I am not sure if this is correct, if it compiles, or if it solves any problem. There is however some timeouts showing up in libusb, for example in https://github.com/libusb/libusb/issues/94#issuecomment-886026188 which I could possibly think is caused by this.

The libusbK.sys backend deals properly with both sync and async requests. The libusb0.sys backend would up to now ignore the overlapped for an async request. I think the rework in libusb 1.0.24 made everything async. The suggested change makes it "fake async". Probably it could be made to work again with libusb changes instead, but I think offering a "fake async" here is good anyway.

Alternatively the overlapped from the caller can be passed down to the DeviceIOControl instead of the extra overlapped currently created in _usb_io_sync(). I will suggest this in another merge request. It still doesn't make it true async. I think the repacking done in usb_control_msg() requires allocating a new buffer for setup + outgoing data, and it is not obvious for me how to free that buffer at the right point in time later, if going asynchronous.